### PR TITLE
Add XSS Demo.mp4 to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@ This project demonstrates a Cross-Site Scripting (XSS) attack using a simple log
 1. [Installation](#installation)
 2. [How to run the code](#how-to-run-the-code)
 3. [Client Side Code](#client-side-code)
-4. [Contribution Guidelines](#contribution-guidelines)
-5. [License Information](#license-information)
+4. [XSS Demo Video](#xss-demo-video)
+5. [Contribution Guidelines](#contribution-guidelines)
+6. [License Information](#license-information)
 
 ## Installation
 
@@ -78,6 +79,11 @@ const apiUrl = 'https://unearthly-hex-679pp459qqgh574r-8001.app.github.dev/colle
 ```
 
 Change your workspace name to your own workspace name in the apiUrl variable.
+
+## XSS Demo Video
+<details><summary>View Demo Video</summary>
+<video src="https://raw.githubusercontent.com/StepSisStuck/API-XSS-Attack/refs/heads/main/XSSDemo.mp4" title="Demonstration video of the software."></video> <!-- Licence for Example_2.webm: MPL-2.0+ OR CC-BY-SA-4.0+ --></details>
+
 
 ## Contribution Guidelines
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,11 @@ Change your workspace name to your own workspace name in the apiUrl variable.
 
 ## XSS Demo Video
 <details><summary>View Demo Video</summary>
-<video src="https://raw.githubusercontent.com/StepSisStuck/API-XSS-Attack/refs/heads/main/XSSDemo.mp4" title="Demonstration video of the software."></video> <!-- Licence for Example_2.webm: MPL-2.0+ OR CC-BY-SA-4.0+ --></details>
+
+
+https://github.com/user-attachments/assets/289917ae-d0b3-43f3-8b9d-1af6f298c824
+
+</details>
 
 
 ## Contribution Guidelines


### PR DESCRIPTION
Add a section for the XSS Demo Video to the `README.md`.

* **Table of Contents**
  - Add "XSS Demo Video" section link after "Client Side Code" section.
  - Adjust numbering for subsequent sections.

* **New Section**
  - Add "XSS Demo Video" section after "Client Side Code" section.
  - Provide a link to the `XSS Demo.mp4` video file within a collapsible details tag.

